### PR TITLE
feat(default): deploy Firefly III

### DIFF
--- a/kubernetes/apps/default/firefly/app/externalsecret.yaml
+++ b/kubernetes/apps/default/firefly/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: firefly
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: hashicorp-vault
+  target:
+    name: firefly-secret
+    template:
+      engineVersion: v2
+      data:
+        APP_KEY: "{{ .APP_KEY }}"
+        DB_CONNECTION: "pgsql"
+        DB_HOST: "{{ .pg_host }}"
+        DB_PORT: "{{ .pg_port }}"
+        DB_DATABASE: "{{ .pg_dbname }}"
+        DB_USERNAME: "{{ .pg_user }}"
+        DB_PASSWORD: "{{ .pg_password }}"
+  dataFrom:
+    - extract:
+        key: default/firefly
+    - extract:
+        key: postgres-16-pguser-firefly
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: crunchy-pgo-secrets
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "pg_$1"

--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
               TRUSTED_PROXIES: "**"
               LOG_CHANNEL: stack
               APP_LOG_LEVEL: notice
-              DEFAULT_LANGUAGE: en_US
+              DEFAULT_LANGUAGE: fr_FR
               DEFAULT_LOCALE: equal
               SITE_OWNER: "firefly@${SECRET_DOMAIN}"
               MAIL_MAILER: smtp

--- a/kubernetes/apps/default/firefly/app/helmrelease.yaml
+++ b/kubernetes/apps/default/firefly/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app firefly
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  values:
+    controllers:
+      firefly:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          app:
+            image:
+              repository: docker.io/fireflyiii/core
+              tag: version-6.2.27
+
+            env:
+              APP_ENV: production
+              APP_DEBUG: "false"
+              APP_URL: "https://firefly.${SECRET_DOMAIN}"
+              TZ: "${TIMEZONE}"
+              TRUSTED_PROXIES: "**"
+              LOG_CHANNEL: stack
+              APP_LOG_LEVEL: notice
+              DEFAULT_LANGUAGE: en_US
+              DEFAULT_LOCALE: equal
+              SITE_OWNER: "firefly@${SECRET_DOMAIN}"
+              MAIL_MAILER: smtp
+              MAIL_HOST: smtp-relay.infrastructure.svc.cluster.local
+              MAIL_PORT: "2525"
+              MAIL_FROM: "firefly@${SECRET_DOMAIN}"
+
+            envFrom:
+              - secretRef:
+                  name: firefly-secret
+
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /login
+                    port: &port 8080
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            group: Misc
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: external
+            namespace: network
+
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
+
+    persistence:
+      upload:
+        existingClaim: *app
+        globalMounts:
+          - path: /var/www/html/storage/upload

--- a/kubernetes/apps/default/firefly/app/kustomization.yaml
+++ b/kubernetes/apps/default/firefly/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/firefly/app/ocirepository.yaml
+++ b/kubernetes/apps/default/firefly/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: firefly
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/firefly/ks.yaml
+++ b/kubernetes/apps/default/firefly/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firefly
+  namespace: &namespace default
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/default/firefly/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 1h
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -27,4 +27,5 @@ resources:
   - ./bichon/ks.yaml
   - ./the-recipe-db/ks.yaml
   - ./bambuddy/ks.yaml
+  - ./firefly/ks.yaml
   #  - ./opencloud/ks.yaml

--- a/kubernetes/apps/infrastructure/crunchy-postgres-operator/cluster/postgrescluster.yaml
+++ b/kubernetes/apps/infrastructure/crunchy-postgres-operator/cluster/postgrescluster.yaml
@@ -319,6 +319,11 @@ spec:
         - "forgejo"
       password:
         type: AlphaNumeric
+    - name: "firefly"
+      databases:
+        - "firefly"
+      password:
+        type: AlphaNumeric
   backups:
     pgbackrest:
       configuration:


### PR DESCRIPTION
Add a Firefly III personal finance manager deployment in the default
namespace, backed by the shared Crunchy PostgreSQL cluster. Adds a
dedicated firefly user/database, an ExternalSecret pulling APP_KEY from
hashicorp-vault and DB credentials from the Crunchy secret store, and a
VolSync-backed PVC for /var/www/html/storage/upload. Exposed externally
at firefly.${SECRET_DOMAIN} via the external Envoy gateway.

https://claude.ai/code/session_01TBwv819WeWPSQuW47NyhX8