### PR TITLE
fix(authentik): add resource requests and loosen probe timeouts

### DIFF
--- a/kubernetes/apps/auth/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/authentik/app/helmrelease.yaml
@@ -47,6 +47,29 @@ spec:
       autoscaling:
         enabled: true
         minReplicas: 2
+
+      # Required by the CPU-based HPA: without requests.cpu the HPA reports
+      # FailedGetResourceMetric. Sized from observed usage (~25m CPU / ~670Mi RSS).
+      resources:
+        requests:
+          cpu: 100m
+          memory: 768Mi
+        limits:
+          memory: 1500Mi
+
+      # /-/health/{live,ready}/ are served by the same ASGI worker pool as user
+      # traffic: OIDC authorize bursts push p99 request latency to 2-4.5s, which
+      # blew through the 3s default timeout and flapped pods out of rotation.
+      livenessProbe:
+        timeoutSeconds: 10
+        periodSeconds: 15
+        failureThreshold: 5
+      readinessProbe:
+        timeoutSeconds: 10
+        failureThreshold: 3
+      startupProbe:
+        timeoutSeconds: 10
+
       metrics:
         enabled: true
         serviceMonitor:
@@ -65,6 +88,27 @@ spec:
       autoscaling:
         enabled: true
         minReplicas: 2
+
+      # Required by the CPU-based HPA. Sized from observed usage (~58m CPU /
+      # ~280Mi RSS); 200m keeps steady-state utilization ~30% so the HPA only
+      # scales on real task bursts instead of flapping.
+      resources:
+        requests:
+          cpu: 200m
+          memory: 384Mi
+        limits:
+          memory: 1Gi
+
+      # `ak healthcheck` spawns a full Python interpreter, which can exceed the
+      # 3s default under load.
+      livenessProbe:
+        timeoutSeconds: 10
+        periodSeconds: 15
+        failureThreshold: 5
+      readinessProbe:
+        timeoutSeconds: 10
+      startupProbe:
+        timeoutSeconds: 10
 
     prometheus:
       rules:


### PR DESCRIPTION
## Problème

Deux symptômes distincts sur `auth/authentik` :

**(a) HPA cassés depuis leur création.** `server.autoscaling` et `worker.autoscaling` sont activés et ciblent `Resource/cpu` à `averageUtilization: 50`, mais les deux conteneurs tournaient avec `resources: {}` (le chart laisse `server.resources`/`worker.resources` vides par défaut et la HelmRelease ne les surchargeait pas). Un target `Utilization` est un ratio sur `requests.cpu` — sans request, rien à calculer :

```
Warning  FailedGetResourceMetric  horizontalpodautoscaler/authentik-server
  failed to get cpu utilization: missing request for cpu in container server
```

`ScalingActive=False` depuis `2025-05-15T16:42:04Z`, soit 25s après la création des HPA. `authentik-worker` affichait `desiredReplicas: 0`.

**(b) Probes en timeout par intermittence.**

```
Readiness probe failed: Get "http://10.69.0.172:9000/-/health/ready/": context deadline exceeded
Liveness probe failed:  Get "http://10.69.4.154:9000/-/health/live/": context deadline exceeded
```

Ce n'est ni la saturation ni Postgres : nœuds à 9-12% CPU, `restartCount: 0` partout, `lastState: {}` (aucun OOMKill), primary PG idle à 98m. `/-/health/{live,ready}/` sont servis par le **même pool ASGI** que le trafic utilisateur ; sur ~2300 lignes de logs, p50 = 60ms et p90 = 94ms, mais avec un long tail qui dépasse les `timeoutSeconds: 3` par défaut du chart :

- `4510ms` sur `/application/o/authorize/` (flux OIDC outpost)
- `2102ms` sur `/health/ready/`, `1206ms` sur `/health/live/`
- 3 × `CancelledError exception in shielded future` = les requêtes coupées par le kubelet

La fenêtre des `Unhealthy` coïncide exactement avec le pic `authorize`.

## Correctif

`server` — `requests: cpu 100m / memory 768Mi`, `limits.memory: 1500Mi` (observé ~25m / ~670Mi).
`worker` — `requests: cpu 200m / memory 384Mi`, `limits.memory: 1Gi` (observé ~58m / ~280Mi ; 200m maintient l'utilisation à ~30% en régime stable, sinon le HPA flapperait en permanence).
Probes des deux : `timeoutSeconds: 10`, liveness à `periodSeconds: 15` / `failureThreshold: 5`.

Pas de `limits.cpu`, conforme à la convention du repo (`home/zigbee2mqtt`, `development/semaphore`, `development/forgejo-runner`).

## Validation

`helm template` sur le chart 2026.8.2 : le deep-merge conserve bien les `httpGet.path` et `exec.command` d'origine — rendu vérifié avec `/-/health/live/`, `/-/health/ready/` et `ak healthcheck` intacts. `kubectl kustomize` passe.

Au prochain reconcile, le rollout recrée les pods avec les requests et les HPA repassent `ScalingActive=True` d'eux-mêmes. Aucune action manuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)