### PR TITLE
fix(recyclarr): set until_quality on FR-ANIME-VOSTFR profile

### DIFF
--- a/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
@@ -30,6 +30,10 @@ spec:
           schedule: "@daily"
           successfulJobsHistory: 1
           failedJobsHistory: 1
+          # A bad profile/CF config fails deterministically; the chart default
+          # (6) then spawns 7 Error pods per run. One retry is enough to ride
+          # out a transient *arr API hiccup.
+          backoffLimit: 1
         containers:
           app:
             image:

--- a/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
@@ -118,6 +118,11 @@ sonarr:
           enabled: true
         upgrade:
           allowed: false
+          # Required whenever an explicit `qualities` list is given: without it
+          # Recyclarr sends cutoff=0 (Unknown, not allowed) and Sonarr rejects
+          # the profile with "HTTP 400: Cutoff must be an allowed quality or
+          # group". Must name a quality present in the list below.
+          until_quality: Bluray-1080p
         min_format_score: 100
         score_set: french-anime-vostfr
         quality_sort: top
@@ -258,7 +263,6 @@ radarr:
       - trash_ids:
           # Unwanted
           - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           - 5c44f52a8714fdd79bb4d98e2673be1f # Retags


### PR DESCRIPTION
## Problème

7 pods `recyclarr-29818080-*` en `Error` sur le même run (namespace `downloads`).

Le profil `FR-ANIME-VOSTFR` — inliné à la main sur `sonarr-anime` car il n'a plus d'équivalent dans les TRaSH guides — fournit une liste `qualities:` explicite mais pas de `upgrade.until_quality`. Recyclarr envoie alors `cutoff: 0` (quality `Unknown`, `allowed: false`) et Sonarr refuse le profil :

```
[ERR] sonarr-anime: HTTP 400: Cutoff must be an allowed quality or group
[ERR] sonarr-anime: Request body: {"name":"FR-ANIME-VOSTFR","upgradeAllowed":false,"cutoff":0,...
```

La doc Recyclarr est explicite sur `until_quality` : *« This property is required if you also specify a `qualities` list »*. Sonarr 4.0+ / Radarr 5.26+ imposent en plus que le cutoff soit une quality autorisée.

L'échec est déterministe, donc les 6 retries du chart (`backoffLimit` par défaut) produisaient 7 pods Error à chaque run.

## Correctif

- `until_quality: Bluray-1080p` sous `upgrade:` — le groupe est présent dans la liste `qualities` et `allowed: true`, cohérent avec `quality_sort: top`.
- Suppression du trash_id `90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)`, retiré des TRaSH guides et qui loguait `[WRN] radarr: Invalid trash_id` à chaque run.
- `cronjob.backoffLimit: 1` — une erreur de config ne se répare pas en réessayant 6 fois ; un retry suffit à absorber un hoquet transitoire de l'API *arr.

## Hors périmètre

Les `[INF] ... conflicting scores in profile ... 50 vs -10000 (first value wins)` sur x265 (HD) sont des warnings connus (le bloc x265 score 50 précède `Language: Not Original` à -10000). Sans rapport avec l'échec, non touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)