### PR TITLE
fix(pacman): exclude upstream temp files from mirror sync

### DIFF
--- a/kubernetes/apps/development/pacman/app/helmrelease.yaml
+++ b/kubernetes/apps/development/pacman/app/helmrelease.yaml
@@ -58,10 +58,15 @@ spec:
                 LOG=/tmp/rsync.log
                 START=$(date +%s)
 
+                # --exclude='.*' skips upstream's in-flight temp files (e.g.
+                # .extra.files.tar.gz.dI031r), which are mode 0600 on the mirror
+                # and make rsync fail with "Permission denied (13)" -> exit 23
+                # whenever we sync while upstream is mid-update.
                 rsync -rtlvH --safe-links --delete-after --delete-excluded \
                   --delay-updates --no-motd --stats --itemize-changes \
                   --timeout=600 --contimeout=60 \
-                  --exclude='iso/' --exclude='*-debug/' --exclude='sources/' \
+                  --exclude='.*' --exclude='iso/' --exclude='*-debug/' \
+                  --exclude='sources/' \
                   rsync://ftp.halifax.rwth-aachen.de/archlinux/ /srv/repo/ >"$LOG" 2>&1
                 RC=$?
                 cat "$LOG"


### PR DESCRIPTION
## Problème

`pacman-sync` (namespace `development`) échoue par intermittence — 5 pods en `Error` étalés sur ~5 jours, entrecoupés de runs `Completed`.

rsync sort en code 23 quand la synchro tombe pendant que le miroir amont est lui-même en cours de mise à jour (le marqueur `Archive-Update-in-Progress-ftp.halifax.rwth-aachen.de` est visible dans le listing) :

```
rsync: [sender] send_files failed to open "/extra/os/x86_64/.extra.files.tar.gz.dI031r" (in archlinux): Permission denied (13)
IO error encountered -- skipping file deletion
rsync error: some files/attrs were not transferred (see previous errors) (code 23)
```

`.extra.files.tar.gz.dI031r` est un fichier temporaire en vol côté amont, créé en mode 0600 donc illisible. Le script tolérait déjà le code 24 (fichiers disparus en cours de transfert) mais pas ce cas-là.

## Correctif

Ajout de `--exclude='.*'` aux options rsync — c'est ce que fait le `syncrepo.sh` officiel d'Arch. Les temporaires cachés ne sont plus listés, donc plus de `Permission denied`.

`--delete-excluded` était déjà présent et nettoiera au passage les temporaires résiduels côté PVC. Pas de risque pour `--delay-updates` : rsync protège automatiquement son propre partial-dir `.~tmp~` des règles de suppression (« *it will also prevent the untimely deletion of partial-dir items on the receiving side* », man rsync, `--partial-dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)