### PR TITLE
fix(spegel): raise registry probe timeouts via post-renderer

### DIFF
--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -28,3 +28,28 @@ spec:
       enabled: true
     serviceMonitor:
       enabled: true
+  # The chart leaves the registry probes at the Kubernetes default timeout of 1s.
+  # /healthz (0.3.x) and /readyz (0.7.x) are served by the same HTTP mux that serves
+  # mirrored blobs, so under pull load the probe regularly exceeds 1s and the Pod
+  # flaps to NotReady ("context deadline exceeded"). The chart exposes no probe
+  # tunables, so patch them after rendering.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: DaemonSet
+              name: ^spegel$
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: spegel
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: registry
+                        readinessProbe:
+                          timeoutSeconds: 5
+                        startupProbe:
+                          timeoutSeconds: 5


### PR DESCRIPTION
## Problème

Les pods `spegel` (kube-system) flappent en `NotReady` de façon chronique :

```
Readiness probe failed: Get "http://10.69.3.223:5000/healthz": context deadline exceeded
```

Volumétrie sur 3 nœuds : `spegel-rsqr8` 843 occurrences, `spegel-js8l6` 719, `spegel-csgfh` 435 — depuis le 2026-06-09. Les 6 pods sont `1/1 Running` actuellement : `failureThreshold: 3` n'est jamais atteint consécutivement, c'est du flapping, pas une panne.

**Cause :** `Readiness: http-get http://:registry/healthz ... timeout=1s` — c'est le **même serveur HTTP** qui sert les blobs mirrorés. Sous charge de pull, le handler de santé dépasse 1s. Les logs confirment la charge concomitante :

```
"msg":"request to mirror failed","err":"expected mirror to respond with 200 OK but received: 500 Internal Server Error","mirror":"10.69.0.99:5000"
"err":"could not determine size of blob with digest sha256:a985...: content not found","status":500,"handler":"blob"
```

Écarté : pas d'OOM (redémarrages datés du 2026-06-08 avec `exitCode: 0, reason: Completed`), pas de pression mémoire (25-33Mi pour une limite de 128Mi).

## Correctif

Le chart n'expose **aucun** réglage de probe — ni en 0.3.0 (aucune clé dans `helm show values`) ni en 0.7.4 (seulement `livenessProbe.enabled`). D'où le `postRenderers` Kustomize portant `timeoutSeconds: 5` sur `readinessProbe` et `startupProbe` du conteneur `registry`.

Le target est ancré `name: ^spegel$` **volontairement** : les sélecteurs Kustomize sont des regex non ancrées, et sans ancres le patch toucherait aussi le DaemonSet `spegel-cleanup` (hook post-delete du chart 0.7.4), dont le conteneur s'appelle `cleanup` — le strategic merge y aurait injecté un conteneur `registry` fantôme. Rendu validé avec `kustomize build` sur les deux DaemonSets du chart 0.7.4.

Compatible 0.3.0 comme 0.7.4 : le patch ne touche que `timeoutSeconds`, pas le path (`/healthz` en 0.3.x, `/readyz` en 0.7.x). Les deux probes existent déjà avec leur `httpGet` sur le DS vivant, le merge ne fait que surcharger le timeout.

## ⚠️ Ne débloque PAS l'upgrade — voir issue séparée

La HelmRelease est aussi en `Stalled` sur un tout autre problème : l'upgrade 0.3.0 → 0.7.4 échoue parce que le chart 0.7.4 ajoute `app.kubernetes.io/component: spegel` à `spec.selector.matchLabels`, champ immuable sur un DaemonSet. Ça demande une action manuelle (`kubectl delete daemonset spegel -n kube-system` puis `flux reconcile hr spegel -n kube-system --force`) qui n'a pas sa place dans une PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)