### PR TITLE
fix(bichon): pin to 1.4.3 until the v2 data migration is done

### DIFF
--- a/kubernetes/apps/default/bichon/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bichon/app/helmrelease.yaml
@@ -25,9 +25,17 @@ spec:
 
         containers:
           app:
+            # bichon 2.x rewrote the on-disk store (fjall -> bichon-blob) and
+            # refuses to start on a v1.x data layout:
+            #   ERROR bichon_server: Incompatible data format detected.
+            #   Error: Generic { message: "Legacy data layout detected" }
+            # The migration is the interactive `bichon-admin` TUI shipped in the
+            # image, so it cannot run as an initContainer/Job. Pinned to the last
+            # v1.x release until the migration is done by hand on the PVC; bump
+            # to 2.x only afterwards.
             image:
               repository: docker.io/rustmailer/bichon
-              tag: 2.0.2
+              tag: 1.4.3
 
             env:
               BICHON_HTTP_PORT: &httpPort 15630


### PR DESCRIPTION
> ⚠️ **bichon est actuellement DOWN** (HelmRelease `suspend: true`, Deployment à `replicas: 0`). Voir la section « Actions manuelles » : cette PR seule ne remet pas le service en ligne.

## Problème

HelmRelease `default/bichon` en `False` : *Helm rollback to previous release default/bichon.v36 succeeded*.

bichon 2.x a réécrit le store sur disque (fjall → bichon-blob) et refuse de démarrer sur une donnée v1.x. Reproduit de façon déterministe en lançant `docker.io/rustmailer/bichon:2.0.2` sur un clone CSI du PVC `bichon`, avec le même securityContext / env / secret que la HelmRelease :

```
ERROR bichon_server: Incompatible data format detected.
ERROR bichon_server: Your data was created by an older version of Bichon and must be migrated before use.
ERROR bichon_server: Please run: bichon-admin
ERROR bichon_server:   - v1.x (Fjall) → v2.x (bichon-blob)
Error: Generic { message: "Legacy data layout detected", ... code: InternalError }
```

Sortie en code 1 immédiatement, avant même que les probes n'entrent en jeu. Aucun pod n'est donc jamais devenu ready → Helm a atteint son timeout de 10 min trois fois (`upgradeFailures: 3`, `lastAttemptedReleaseActionDuration: 10m0.9s`) → rollback.

Le même image sur un `/data` **vide** démarre et sert `GET /` → 200 : l'image, les probes, le securityContext, la route et le secret sont tous corrects. C'est uniquement le format de données.

Le chart n'y est pour rien : le repo épingle déjà app-template 5.1.0 et l'OCIRepository est à jour ; le cluster est sur 5.0.1 simplement parce que c'est ce que porte la release `v38` sur laquelle il a rollback.

## Correctif

Tag `2.0.2` → `1.4.3`, vérifié comme démarrant proprement sur la même donnée clonée (`[memdb] replayed 36 WAL entries`, synchro IMAP reprise). Un commentaire documente le blocage et l'erreur exacte pour que la prochaine PR Renovate vers 2.x ne soit pas mergée à l'aveugle.

## Actions manuelles (état cluster, hors repo)

La HelmRelease a été suspendue et le Deployment scalé à zéro pendant l'investigation ; Flux ne peut défaire ni l'un ni l'autre. **Une fois cette PR mergée et reconciliée** :

```bash
flux resume hr bichon -n default
kubectl scale deploy bichon -n default --replicas=1   # fallback si helm ne le restaure pas
```

Ne pas faire `flux resume` **avant** que le pin ne soit sur `main`, sinon l'upgrade 2.0.2 réessaie et brûle un nouveau cycle de rollback.

## Pour passer à 2.x plus tard

`bichon-admin` est une TUI interactive (elle panique en `IO(Custom { kind: NotConnected, error: "not a terminal" })` sans PTY), donc impossible à emballer dans un initContainer ou un Job. Il faut : scaler à 0, faire un snapshot VolSync/Ceph, puis `kubectl run -it --rm bichon-migrate --image=docker.io/rustmailer/bichon:2.0.2` avec le PVC `bichon` monté sur `/data` et un TTY, dérouler l'option « v1.x (Fjall) → v2.x (bichon-blob) », et enfin bumper le tag.

## Note sans rapport

Le secret Vault `default/bichon` a `BICHON_ENCRYPT_PASSWORD` positionné à la chaîne littérale `BICHON_ENCRYPT_PASSWORD` — un placeholder jamais remplacé. L'app fonctionne avec, mais ça mérite une rotation (avec précaution : cette valeur chiffre les données au repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)