### PR TITLE
fix(kopia): widen liveness tolerance to survive NFS stalls

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -30,6 +30,13 @@ spec:
               - --refresh-interval=5m
               - --without-password
             probes:
+              # The kopia server serves "/" from the same goroutine pool that
+              # refreshes the NFS-backed repository index (~7k index blobs
+              # between maintenance runs). A 1s timeout / 3 failures (30s) made
+              # kubelet SIGKILL the server on every NFS hiccup -> 110 restarts,
+              # all exit 137 with reason=Error (never OOMKilled; peak RSS 586Mi
+              # against a 1Gi limit). 30s period / 10s timeout / 5 failures
+              # gives a 150s tolerance window instead.
               liveness: &probes
                 enabled: true
                 custom: true
@@ -38,9 +45,9 @@ spec:
                     path: /
                     port: *port
                   initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 5
               readiness: *probes
               # Kopia loads the whole repository index from the NFS backend on
               # startup; with thousands of blobs over NFS this can take several


### PR DESCRIPTION
## Problème

Le Deployment `kopia` (volsync-system) a redémarré **110 fois**.

Ce n'est pas un OOMKill :

| Preuve | Valeur |
|---|---|
| `Last State` | `Terminated, Reason: **Error**, Exit Code: 137` — jamais `OOMKilled` |
| Durée de vie du conteneur tué | 19:40:48 → 19:46:48 = **6 minutes** |
| RSS max sur 14 j | **586 MiB** pour une limite de **1 GiB** |
| Throttling CPU | aucune série `container_cpu_cfs_throttled_periods_total` (pas de limite CPU) |
| Charge du nœud `fool` pendant les kills | CPU ~9 %, `load15` ~1.6 — nœud au repos |

Ce sont les probes :

```
prober_probe_total{probe_type="Liveness",result="failed"}      = 396   → /3 failureThreshold ≈ 132 kills
prober_probe_total{probe_type="Startup",result="successful"}   = 111   ≈ nombre de démarrages
```

Le serveur kopia répond sur `/` depuis le même pool que le rafraîchissement d'index (`--refresh-interval=5m`) sur un dépôt NFS TrueNAS dont l'index a dérivé :

```
Found too many index blobs (6870), this may result in degraded performance.
Please ensure periodic repository maintenance is enabled or run 'kopia maintenance'.
```

Avec `timeoutSeconds: 1` / `failureThreshold: 3`, la tolérance n'était que de **30 s** — le moindre hoquet NFS >3 s déclenchait SIGTERM puis SIGKILL. Le log `--previous` se termine d'ailleurs sur `Shutting down HTTP server`, signature d'un arrêt gracieux provoqué et non d'un OOM.

## Correctif

`periodSeconds: 30` / `timeoutSeconds: 10` / `failureThreshold: 5` → **150 s** de tolérance. L'ancre YAML `&probes` est partagée avec la readiness, les deux suivent.

## Ce que ça ne corrige pas — 2 pistes hors repo

**1. L'origine du stall NFS est côté TrueNAS.** Les redémarrages arrivent en rafales de 3-4, **une fois par jour entre 17:30 et 18:00 UTC** (19:30-20:00 Paris), quotidiennement depuis le 01/09. Aucun autre pod du cluster ne redémarre dans cette fenêtre, le nœud est idle, la mémoire est plate. À chercher dans *TrueNAS → Data Protection* : tâche quotidienne (snapshot périodique / réplication / scrub / S.M.A.R.T. long) sur le pool `tank` qui stalle l'export `/mnt/tank/Backup/kopia_backup`. Cette PR rend kopia tolérant au symptôme, elle ne supprime pas la cause.

**2. La dette d'index.** L'index passe de **5065** blobs juste après maintenance à **6870+** avant la suivante, et la `KopiaMaintenance` ne tourne que 2×/jour (`30 3,15 * * *`) en mettant déjà 370 s. Option à arbitrer séparément : passer à `30 3,9,15,21 * * *` dans `kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml`, ou une compaction ponctuelle `kubectl exec -n volsync-system deploy/kopia -- kopia maintenance run --full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)