### PR TITLE
fix(bazarr): add startup probe so the 1.6.0 migration can finish

### DIFF
--- a/kubernetes/apps/downloads/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/app/helmrelease.yaml
@@ -51,6 +51,21 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+              # Bazarr 1.6.0 runs a long one-shot Alembic migration (subtitles
+              # offloaded to dedicated tables + ~40 new indexes) before binding
+              # the HTTP port. Measured ~2 min on this library, so the liveness
+              # probe must stay suspended until the migration completes.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 1
+                  failureThreshold: 60
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Ce n'est pas le chart

`helm template` d'`app-template` **5.0.1 vs 5.1.0** avec les valeurs exactes de bazarr produit une sortie **rigoureusement identique**, au seul label `helm.sh/chart` près. Aucune clé renommée, aucun `securityContext` / `route` / `persistence` incompatible.

Le coupable est le bump d'image **1.5.6 → 1.6.0** (commit `71f6b17f9`), arrivé *avant* le bump de chart (`12ffae549`). Le ReplicaSet `bazarr-599d8dfc57` (revision 29, image 1.6.0, créé il y a 67 j, donc bien avant le passage en 5.1.0) a des `volumeMounts` strictement identiques au RS sain — et c'est ce même RS qui est réutilisé à chaque tentative 5.1.0. Les échecs ont commencé avec l'image.

## Mécanisme, reproduit et mesuré

Bazarr tourne sur PostgreSQL (Crunchy `postgres-16` via pgbouncer, `bazarr-db-secret`), pas SQLite. La base est à la révision Alembic `df76a4410347`. La 1.6.0 embarque 4 révisions supplémentaires, dont `0124f9e278fb` qui sort les sous-titres de `table_episodes`/`table_movies` vers des tables dédiées — insertion ligne par ligne avec un SAVEPOINT par sous-titre sur **15 934 épisodes / 1 939 films** — puis crée ~40 index.

Base `bazarr` clonée en `bazarr_migtest`, image 1.6.0 lancée dessus :

```
16:23:48  démarrage
16:23:57 → 16:25:25   health=DOWN   alembic=df76a4410347   eps_subs=0
16:25:36              health=UP     alembic=0124f9e278fb   eps_subs=25709
```

**~105 s** pendant lesquels le port HTTP n'est pas ouvert. Or la liveness est en `initialDelaySeconds: 0` / `periodSeconds: 10` / `failureThreshold: 3` → kubelet tue le conteneur à **~30 s**, la migration repart de zéro, boucle infinie, le Deployment ne progresse jamais, Helm timeout à 10 min :

```
timeout waiting for: [Deployment/downloads/bazarr status: 'InProgress']
```

→ rollback en 5.0.1 / 1.5.6. Il n'y avait **aucune startup probe**, contrairement à `sabnzbd`, `qbittorrent` et `slskd` du même namespace.

L'état de la base confirme le scénario : `table_episodes_subtitles` / `table_movies_subtitles` existent déjà (créées par `create_all()` au boot) mais sont **vides**, et `alembic_version` n'a jamais bougé. Aucune migration n'a jamais été committée.

## Correctif

Startup probe custom sur `/health:6767`, `periodSeconds: 5`, `failureThreshold: 60` = **300 s de budget** (~3× la marge mesurée). Tant qu'elle n'a pas réussi, kubelet suspend liveness et readiness et laisse la migration aller au bout. 300 s reste sous le `progressDeadlineSeconds: 600` du Deployment et le `timeout: 10m` du HelmRelease.

Rendu validé par `helm template` sur le chart 5.1.0 : le seul delta est le bloc `startupProbe` attendu.

## Au merge

Le changement de `spec` génère une nouvelle génération : Flux sort du `Stalled` et relance l'upgrade seul. Prévoir **~2 min d'indisponibilité** de bazarr (stratégie `Recreate`) le temps de la migration — one-shot.

Les ressources de diagnostic ont été nettoyées (pods `bazarr-diag-*`, base `bazarr_migtest`). La base de production n'a pas été modifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)